### PR TITLE
fix(macos): ignore leftover Finder click after TrayApp show

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,7 @@ kotlinx-coroutines = "1.11.0"
 compose = "1.12.0"
 detekt = "1.23.8"
 ktlint = "12.1.2"
-nucleus = "2.5.0"
-nucleus-plugin = "2.5.0"
+nucleus = "2.5.5"
 
 [libraries]
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -26,4 +25,4 @@ vannitktech-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-nucleus = { id = "dev.nucleusframework", version.ref = "nucleus-plugin" }
+nucleus = { id = "dev.nucleusframework", version.ref = "nucleus" }

--- a/tray-app/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/trayapp/TrayApp.kt
+++ b/tray-app/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/trayapp/TrayApp.kt
@@ -614,12 +614,18 @@ private fun TrayAppImplPanel(
                         instanceKey, widthPx, heightPx, horizontalOffset, verticalOffset,
                     )
             }
+            // Stamp before show(): a leftover Finder mouseDown on the desktop
+            // (same gesture that opened the tray) can land in onOutsideClick
+            // before the panel is on screen. lastShownAtMs starts at 0, which
+            // would make minVisibleDurationMs a no-op and hide immediately.
+            lastShownAtMs.set(now)
             trayAppState.show()
         }
     }
 
     LaunchedEffect(isVisible) {
         if (isVisible) {
+            lastShownAtMs.set(System.currentTimeMillis())
             if (!popupOnScreen) {
                 val preComputed = pendingPosition
                 pendingPosition = null
@@ -712,11 +718,18 @@ private fun TrayAppImplPanel(
         size = currentWindowSize,
         focusable = true,
         onOutsideClick = {
-            // The monitor is process-wide: ignore clicks while already hidden.
+            // Process-wide monitor: ignore while hidden, and drop leftover
+            // Finder desktop clicks from the same gesture that opened us.
+            // Delaying those hides (minVisibleDurationMs) would flash-close.
             if (trayAppState.isVisible.value) {
-                lastDismissAtMs.set(System.currentTimeMillis())
-                debugln { "[TrayApp] outside click dismiss, dismissMode=$dismissMode" }
-                if (dismissMode == TrayWindowDismissMode.AUTO) requestHideExplicit()
+                val sinceShow = System.currentTimeMillis() - lastShownAtMs.get()
+                if (sinceShow < minVisibleDurationMs) {
+                    debugln { "[TrayApp] outside click ignored (${sinceShow}ms after show)" }
+                } else {
+                    lastDismissAtMs.set(System.currentTimeMillis())
+                    debugln { "[TrayApp] outside click dismiss, dismissMode=$dismissMode" }
+                    if (dismissMode == TrayWindowDismissMode.AUTO) requestHideExplicit()
+                }
             }
         },
         onPreviewKeyEvent = onPreviewKeyEvent,


### PR DESCRIPTION
## Summary

- Stamp `lastShownAtMs` before `show()` so a leftover Finder `mouseDown` on the desktop cannot hide the panel immediately (`lastShownAtMs` used to start at 0, which made `minVisibleDurationMs` a no-op).
- Ignore `onOutsideClick` for `minVisibleDurationMs` after show instead of delaying the hide (a delayed hide would flash-close).
- Bump Nucleus to 2.5.5 for the companion Tao standalone-panel fix (stay off Show Desktop, skip status-item / context-menu as outside clicks).

## Type

fix

## Test plan

- [x] `./gradlew :tray-app:jvmTest ktlintCheck`
- [ ] macOS: only the desktop visible, click the tray icon then the wallpaper — popup fades in place, no Show Desktop slide
- [ ] macOS: right-click the tray icon with the popup visible — context menu opens, popup stays
- [ ] macOS: left-click the tray icon with the popup visible — still toggles closed