### PR TITLE
fix: propagate composable menu DSL state changes to the native menu

### DIFF
--- a/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/menu/impl/RecordingComposableScope.kt
+++ b/src/jvmMain/kotlin/dev/nucleusframework/composenativetray/menu/impl/RecordingComposableScope.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.composenativetray.menu.impl
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -22,7 +23,12 @@ import org.jetbrains.compose.resources.painterResource
  * functions inside the tray DSL without hoisting them above `application { … }`.
  */
 internal class RecordingComposableScope : ComposableTrayMenuScope {
-    private val ops = mutableListOf<MenuOp>()
+    // Snapshot-state backed: when only the user's menu lambda recomposes (a state it reads
+    // changed), the DSL re-records into this list. Readers of snapshot() — the Tray wrapper
+    // that computes the menu fingerprint — get invalidated by that write and re-record the
+    // whole menu with a fresh scope, so label/enabled/checked changes reach the native menu
+    // without the caller disposing the tray (issue #434).
+    private val ops = mutableStateListOf<MenuOp>()
 
     fun snapshot(): List<MenuOp> = ops.toList()
 


### PR DESCRIPTION
Fixes #434

## Root cause

The report blamed the label pipeline, but the plain `TrayMenuBuilder` path is fine — the bug is specific to the **composable-DSL overloads** (`ComposableTray.kt`), which is what trailing-lambda callers actually resolve to.

`rememberRecordedMenuContent` invokes the user's `@Composable ComposableTrayMenuScope.() -> Unit` lambda and records it into a plain `mutableListOf`. When state read inside that lambda changes (e.g. `label = if (dashboardOpen) … else …`), Compose restarts **only the lambda's own recompose scope**: the DSL re-records into the old, abandoned `RecordingComposableScope`, while the outer function — `snapshot()`, `structuralFingerprint()`, `remember(fingerprint)`, and the underlying `Tray`'s `LaunchedEffect` — never re-runs. The native menu keeps the stale text until something else forces a full rebuild, which is exactly the `key(...)` workaround from the issue.

Diagnosed with a timed repro (label flip every 2 s + stack traces): the menu lambda re-ran on every flip via `RecomposeScopeImpl.compose` (lambda-only restart), while `Tray` never recomposed and no native update was queued.

## Fix

Back the recorded ops with `mutableStateListOf`. Now a lambda-only restart *writes snapshot state* that the Tray wrapper reads through `snapshot()`, so the wrapper is invalidated, re-records the whole menu with a fresh scope, computes a new fingerprint, and the native menu rebuilds. Submenus chain the same way (child list read by the parent scope).

One line of behavior, verified on Windows 11 with the issue's repro shape:

- each flip → re-record with new label → new `menuHash` → `LaunchedEffect` relaunch → `WindowsTrayManager` processes the update
- exactly one extra recomposition per state change, no recomposition loop (quiet between flips)
- covers `label`, `isEnabled`, and `checked` alike (all in the fingerprint)

## Testing

- Timed repro run before/after (before: zero native updates after init; after: one per flip).
- `compileKotlinJvm` (lib, tray-app, demo), `ktlintCheck`, `detekt`, `jvmTest` all pass.